### PR TITLE
Add includes to fix compiler errors

### DIFF
--- a/src/include/common/SocketException.h
+++ b/src/include/common/SocketException.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstring>
 #include <string>
 #include <exception>         // For exception class
 

--- a/src/include/proxy/ProxyConnectionHandler.h
+++ b/src/include/proxy/ProxyConnectionHandler.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <atomic>
+#include <memory>
 #include <mutex>
 #include "../common/Socket.h"
 


### PR DESCRIPTION
Clang7 on Ubuntu 18.04 reported being unable to find `strerror` in
`SocketException.cpp`, so `cstring` is added to `SocketException.h`.

The same environment also reported being unable to find
`std::unique_ptr` and `std::atomic` in `ProxyConnectionHandler.h`, so
`memory` and `atomic` are added there.